### PR TITLE
Added overflow and overscroll options to Table of Contents (aside) element

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "reading-time": "^1.5.0",
     "satori": "^0.11.3",
     "sharp": "^0.33.5",
+    "tailwind-scrollbar-hide": "^2.0.0",
     "tailwindcss": "^3.4.17"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       sharp:
         specifier: ^0.33.5
         version: 0.33.5
+      tailwind-scrollbar-hide:
+        specifier: ^2.0.0
+        version: 2.0.0(tailwindcss@3.4.17)
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.17
@@ -3656,6 +3659,11 @@ packages:
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
     engines: {node: '>=10.0.0'}
+
+  tailwind-scrollbar-hide@2.0.0:
+    resolution: {integrity: sha512-lqiIutHliEiODwBRHy4G2+Tcayo2U7+3+4frBmoMETD72qtah+XhOk5XcPzC1nJvXhXUdfl2ajlMhUc2qC6CIg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >= 4.0.0 || >= 4.0.0-beta.8 || >= 4.0.0-alpha.20'
 
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
@@ -8553,6 +8561,10 @@ snapshots:
       slice-ansi: 4.0.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  tailwind-scrollbar-hide@2.0.0(tailwindcss@3.4.17):
+    dependencies:
+      tailwindcss: 3.4.17
 
   tailwindcss@3.4.17:
     dependencies:

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -34,7 +34,7 @@ const {
     <slot name="top" />
 
     <aside
-      class="fixed h-screen w-fit max-w-sm -translate-x-full overflow-y-auto overscroll-y-none pr-8"
+      class="fixed h-screen w-fit max-w-sm -translate-x-full overflow-y-auto overscroll-y-none pr-8 scrollbar-hide"
     >
       <slot name="aside" />
     </aside>

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -33,7 +33,7 @@ const {
     <Header activeHeaderLink={activeHeaderLink} />
     <slot name="top" />
 
-    <aside class="fixed w-fit max-w-sm -translate-x-full pr-8">
+    <aside class="overflow-y-auto overscroll-y-none fixed h-screen w-fit max-w-sm -translate-x-full pr-8">
       <slot name="aside" />
     </aside>
 

--- a/src/layouts/PageLayout.astro
+++ b/src/layouts/PageLayout.astro
@@ -33,7 +33,9 @@ const {
     <Header activeHeaderLink={activeHeaderLink} />
     <slot name="top" />
 
-    <aside class="overflow-y-auto overscroll-y-none fixed h-screen w-fit max-w-sm -translate-x-full pr-8">
+    <aside
+      class="fixed h-screen w-fit max-w-sm -translate-x-full overflow-y-auto overscroll-y-none pr-8"
+    >
       <slot name="aside" />
     </aside>
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,6 +24,10 @@ export default {
       }
     }
   },
-  plugins: [require('@tailwindcss/typography'), addIconSelectors(['tabler'])],
+  plugins: [
+    require('@tailwindcss/typography'),
+    require('tailwind-scrollbar-hide'),
+    addIconSelectors(['tabler'])
+  ],
   darkMode: ['selector', '[data-mode="dark"]']
 }


### PR DESCRIPTION
**Summarize the proposed changes**
Added overflow and overscroll options to the aside element representing the Table of Contents (ToC) in the PageLayout.astro file. This utilizes the screen width as the height of the scroll bar. 

Added Tailwind-Scrollbar-Hide utility and "scrollbar-hide" class in ToC aside to remove scrollbar for ToC that require it.

This solves issues for an unscrollable ToC when too many headers exist but the ToC is still displayed on the left side of the blog article. Overscroll option prevents the main content from scrolling when the ToC reaches its scrolling limits. Scrollbar-Hide utility removes the scrollbar from the ToC for better styling.

**What is the type of change? Select one or more.**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (please describe)

**Is there any action needed after merging?**
No action needed after merging.

**Please make sure the PR complies with this checklist**
- [x] The change has been tested locally
- [x] The code has been linted and type-checked
- [x] All relevant tests have been run and passed
- [x] There is currently no merge conflict
- [x] No new warnings or errors have appeared (if intended, please describe)

**Additional context**
None
